### PR TITLE
Fix crash on Insanium Reprocessor menu open

### DIFF
--- a/src/main/java/com/focamacho/mysticaladaptations/tiles/InsaniumReprocessorTileEntity.java
+++ b/src/main/java/com/focamacho/mysticaladaptations/tiles/InsaniumReprocessorTileEntity.java
@@ -182,7 +182,7 @@ public class InsaniumReprocessorTileEntity extends BaseInventoryTileEntity imple
 
     @Override
     public Container createMenu(int id, PlayerInventory playerInventory, PlayerEntity player) {
-        return ReprocessorContainer.create(id, playerInventory, this::isUsableByPlayer, this.inventory, this.data);
+        return ReprocessorContainer.create(id, playerInventory, this::isUsableByPlayer, this.inventory, this.getBlockPos());
     }
 
     @Override


### PR DESCRIPTION
Mystical Agriculture changed the way ReprocessorContainer::create works.
While I haven't tested this, I'm pretty sure this will fix the crash...
If not, please try and find time to review the changes that were made to the Mystical Agriculture API/source and update the mod to work with the newer versions.

This should fix #34 